### PR TITLE
Add new libc version to AWS setup instructions

### DIFF
--- a/2024f/writeup-write-a-story.html
+++ b/2024f/writeup-write-a-story.html
@@ -854,6 +854,7 @@ color: red }
 <ul class="simple">
 <li>Run <tt class="docutils literal">sudo dpkg <span class="pre">--add-architecture</span> i386</tt></li>
 <li>Run <tt class="docutils literal">sudo apt update</tt></li>
+<li>Run <tt class="docutils literal">sudo apt install <span class="pre">libc6=2.35-0ubuntu3.8</span> <span class="pre">libc6:i386=2.35-0ubuntu3.8</span></tt></li>
 <li>Run <tt class="docutils literal">sudo apt install <span class="pre">--assume-yes</span> execstack <span class="pre">libc6-dev-i386</span> <span class="pre">libssl-dev:i386</span> python2 python3 <span class="pre">python-pip</span></tt></li>
 <li>Run <tt class="docutils literal">pip2 install sqlalchemy flask</tt></li>
 </ul>

--- a/rst/writeup-write-a-story.rst
+++ b/rst/writeup-write-a-story.rst
@@ -176,6 +176,7 @@ If you're running into problems running the VM on your laptop, follow these dire
 
    - Run ``sudo dpkg --add-architecture i386``
    - Run ``sudo apt update``
+   - Run ``sudo apt install libc6=2.35-0ubuntu3.8 libc6:i386=2.35-0ubuntu3.8``
    - Run ``sudo apt install --assume-yes execstack libc6-dev-i386 libssl-dev:i386 python2 python3 python-pip``
    - Run ``pip2 install sqlalchemy flask``
 


### PR DESCRIPTION
Current AMI image setup instructions result in a dependency conflict. Amended the setup instructions by specifying a specific version of the `libc6` package to install. See Ed issue [here](https://edstem.org/us/courses/65727/discussion/5221061)